### PR TITLE
[CIVIS-9747] MAINT show code examples in docs; add static type checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,11 @@ workflows:
             pip install ".[dev]" && \
             black --check src tests examples
       - pre-build:
+          name: mypy
+          command-run:  |
+            pip install ".[dev]" && \
+            mypy src
+      - pre-build:
           name: twine
           command-run: |
             pip install ".[dev]" && \
@@ -92,6 +97,7 @@ workflows:
           requires:
             - flake8
             - black
+            - mypy
             - twine
             - bandit
           matrix:
@@ -101,5 +107,6 @@ workflows:
           requires:
             - flake8
             - black
+            - mypy
             - twine
             - bandit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
+## [1.5.1] - 2024-11-07
+
+### Fixed
+- Fixed documentation to actually show example code. (#12)
+
 ## [1.5.0] - 2024-10-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.5.1] - 2024-11-07
 
+### Added
+- Added static type checking using mypy. (#12)
+
 ### Fixed
 - Fixed documentation to actually show example code. (#12)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'furo'
+numpydoc_class_members_toctree = False
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None)

--- a/docs/more_examples.rst
+++ b/docs/more_examples.rst
@@ -22,11 +22,11 @@ To override this default behavior,
 use the keyword argument ``start_nodes`` at :func:`~async_graph_data_flow.AsyncExecutor.execute`
 to select which nodes to execute instead and/or supply the arguments to whichever nodes you've selected.
 
-.. literalinclude:: ../../examples/custom_start_nodes.py
+.. literalinclude:: ../examples/custom_start_nodes.py
    :language: python
    :emphasize-lines: 34
 
-.. literalinclude:: ../../examples/custom_start_node_args.py
+.. literalinclude:: ../examples/custom_start_node_args.py
    :language: python
    :emphasize-lines: 34
 
@@ -41,7 +41,7 @@ and therefore all nodes will execute concurrently upon graph execution.
 The start nodes and their arguments at the beginning of the graph execution are available at
 :attr:`~async_graph_data_flow.AsyncExecutor.start_nodes` of :func:`~async_graph_data_flow.AsyncExecutor.execute`.
 
-.. literalinclude:: ../../examples/graph_with_no_edges.py
+.. literalinclude:: ../examples/graph_with_no_edges.py
    :language: python
    :emphasize-lines: 30,39,48
 
@@ -63,7 +63,7 @@ An :class:`~async_graph_data_flow.AsyncExecutor` instance has
 the method :func:`~async_graph_data_flow.AsyncExecutor.turn_on_data_flow_logging`,
 which you can call to turn on and configure logging.
 
-.. literalinclude:: ../../examples/data_flow_logging.py
+.. literalinclude:: ../examples/data_flow_logging.py
    :language: python
    :emphasize-lines: 36-38
 
@@ -74,7 +74,7 @@ By default, each node creates one task at a time.
 To spawn multiple, concurrent tasks from a node,
 set ``max_tasks`` at :func:`~async_graph_data_flow.AsyncGraph.add_node`.
 
-.. literalinclude:: ../../examples/concurrent_tasks_per_node.py
+.. literalinclude:: ../examples/concurrent_tasks_per_node.py
    :language: python
    :emphasize-lines: 25
 
@@ -89,11 +89,11 @@ This behavior can be altered in two different ways:
 * To halt execution at any node, set ``halt_on_exception`` to ``True`` when initializing an :class:`~async_graph_data_flow.AsyncGraph` instance.
 * To halt execution at a specific node, set ``halt_on_exception`` to ``True`` when using :func:`~async_graph_data_flow.AsyncGraph.add_node`  to add the node in question to the graph.
 
-.. literalinclude:: ../../examples/halt_on_exception_at_a_specific_node.py
+.. literalinclude:: ../examples/halt_on_exception_at_a_specific_node.py
    :language: python
    :emphasize-lines: 39
 
-.. literalinclude:: ../../examples/halt_on_exception_at_any_node.py
+.. literalinclude:: ../examples/halt_on_exception_at_any_node.py
    :language: python
    :emphasize-lines: 36
 
@@ -108,7 +108,7 @@ allows access to the exceptions from the nodes,
 and you can determine what to do with this information
 (e.g., raise an exception on your own).
 
-.. literalinclude:: ../../examples/raising_an_exception.py
+.. literalinclude:: ../examples/raising_an_exception.py
    :language: python
    :emphasize-lines: 24-27
 
@@ -121,7 +121,7 @@ Inside a node's async function,
 you may grab the asyncio's running loop,
 then call the synchronous function with this loop.
 
-.. literalinclude:: ../../examples/external_sync_call.py
+.. literalinclude:: ../examples/external_sync_call.py
    :language: python
    :emphasize-lines: 27,29
 
@@ -132,6 +132,6 @@ Sharing state across the async functions is possible
 if you pass the same object around them.
 Such an object can be a custom class instance with methods and attributes as needed.
 
-.. literalinclude:: ../../examples/shared_state.py
+.. literalinclude:: ../examples/shared_state.py
    :language: python
    :emphasize-lines: 21,23,27,30,34,44,45

--- a/docs/technical.rst
+++ b/docs/technical.rst
@@ -41,7 +41,7 @@ see the ``unpack_input`` parameter of :func:`~async_graph_data_flow.AsyncGraph.a
 
     START[ ] -.-> A
     B -.-> STOP[ ]
-    A["async def func2(...):\n&nbsp;&nbsp;&nbsp;&nbsp;...\n&nbsp;&nbsp;&nbsp;&nbsp;yield <strong>foo, bar</strong>"] --> B["async def func3(<strong>foo, bar</strong>):\n&nbsp;&nbsp;&nbsp;&nbsp;...\n&nbsp;&nbsp;&nbsp;&nbsp;yield ..."]
+    A["async def func2(...):<br/>&nbsp;&nbsp;&nbsp;&nbsp;...<br/>&nbsp;&nbsp;&nbsp;&nbsp;yield <strong>foo, bar</strong>"] --> B["async def func3(<strong>foo, bar</strong>):<br/>&nbsp;&nbsp;&nbsp;&nbsp;...<br/>&nbsp;&nbsp;&nbsp;&nbsp;yield ..."]
     style A text-align:left
     style B text-align:left
     style START fill-opacity:0, stroke-opacity:0;
@@ -83,12 +83,12 @@ available to process it.
     style start2 fill-opacity:0, stroke-opacity:0;
 
     subgraph node and its associated queue
-        queue3((queue)) --> node3[task 1, task 2,\ntask 3, ...]
+        queue3((queue)) --> node3[task 1, task 2,<br/>task 3, ...]
     end
 
-    node1 --> |yields\nitems| queue3
-    node2 --> |yields\nitems| queue3
-    node3 -.-> |yields\nitems| STOP[ ]
+    node1 --> |yield<br/>items| queue3
+    node2 --> |yields<br/>items| queue3
+    node3 -.-> |yields<br/>items| STOP[ ]
     style STOP  fill-opacity:0, stroke-opacity:0;
 
 Example
@@ -219,10 +219,10 @@ inputs from the items yielded by ``get_open_brewery_data()``.
 
     flowchart LR
 
-    Q(("Queue items:\n[{'col1': 'val1', ...}, ...]\n[{'col1': 'val1', ...}, ...]\n...\n"))
+    Q(("Queue items:<br/>[{'col1': 'val1', ...}, ...]<br/>[{'col1': 'val1', ...}, ...]<br/>...<br/>"))
     A[get_open_brewery_data]
     B[write_to_csv]
-    A --> |yields\nitems| Q
+    A --> |yields<br/>items| Q
     Q --> B
 
 ``get_open_brewery_data()`` yields a page of the Open Brewery DB data,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "async-graph-data-flow"
-version = "1.5.0"
+version = "1.5.1"
 description = "Asynchronous functions that pass data along a directed acyclic graph"
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "black == 24.10.0",
     "flake8 == 7.1.1",
     "pytest == 8.3.3",
+    "mypy == 1.13.0",
 
     # Managing source distributions
     "build == 1.2.2",

--- a/src/async_graph_data_flow/graph.py
+++ b/src/async_graph_data_flow/graph.py
@@ -3,9 +3,6 @@ from collections import OrderedDict
 from typing import Any, Callable, NamedTuple
 
 
-_DEFAULT_NUM_OF_WORKERS = 1
-
-
 class InvalidAsyncGraphError(Exception):
     pass
 


### PR DESCRIPTION
Of course I messed up something when I did the doc migration from github.io to readthedocs in #11. The code examples don't show up in the built v1.5.0 readthedocs page due to changed file paths -- this present pull request fixes this issue.

While I have a pull request open here, I also went ahead to add static type checking with mypy and adjust code minimally to make the check pass on CI.

---

- [x] Add a concise title to this pull request on the GitHub web interface.
- [x] (For Civis employees only) Prepend the title of this pull request with the internal ticket number. 
- [x] Add a description in this box to describe what this pull request is about.
- n/a If code behavior is being updated (e.g., a bug fix), relevant tests should be added.
- [x] The CircleCI builds should pass, including both the code styling checks as well as the test suite.
- [x] Add an entry to `CHANGELOG.md` at the repository's root level.
